### PR TITLE
tmpfile.write fails with encoding error

### DIFF
--- a/lib/em-ftpd/files.rb
+++ b/lib/em-ftpd/files.rb
@@ -116,7 +116,7 @@ module EM::FTPD
 
       wait_for_datasocket do |datasocket|
         datasocket.on_stream { |chunk|
-          tmpfile.write chunk
+          tmpfile.write chunk.force_encoding 'UTF-8'
         }
         send_response "150 Data transfer starting"
         datasocket.callback {


### PR DESCRIPTION
This patch addresses the encoding errors that crop up under ruby 1.9.3
