### PR TITLE
Prevent em-ftpd from crashing when uploading binary files

### DIFF
--- a/lib/em-ftpd/files.rb
+++ b/lib/em-ftpd/files.rb
@@ -113,6 +113,7 @@ module EM::FTPD
 
     def cmd_stor_tempfile(target_path)
       tmpfile = Tempfile.new("em-ftp")
+      tmpfile.binmode
 
       wait_for_datasocket do |datasocket|
         datasocket.on_stream { |chunk|


### PR DESCRIPTION
Hi,
EM-ftpd crashed when I tried to upload a binary file, with the following backtrace:

```
/home/maarten/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/em-ftpd-0.0.1/lib/em-ftpd/files.rb:119:in `block (2 levels) in cmd_stor_tempfile': "\xFF" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
        from /home/maarten/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/em-ftpd-0.0.1/lib/em-ftpd/base_socket.rb:25:in `call'
        from /home/maarten/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/em-ftpd-0.0.1/lib/em-ftpd/base_socket.rb:25:in `receive_data'
        from /home/maarten/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/eventmachine-1.0.0.beta.4/lib/eventmachine.rb:179:in `run_machine'
        from /home/maarten/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/eventmachine-1.0.0.beta.4/lib/eventmachine.rb:179:in `run'
```

This commit forces the Tempfile to switch to binary mode, which prevents this error from occuring.
