### PR TITLE
Respond to STOR with 226 instead of 200

### DIFF
--- a/lib/em-ftpd/files.rb
+++ b/lib/em-ftpd/files.rb
@@ -100,7 +100,7 @@ module EM::FTPD
           send_response "150 Data transfer starting"
           @driver.put_file_streamed(target_path, datasocket) do |bytes|
             if bytes
-              send_response "200 OK, received #{bytes} bytes"
+              send_response "226 OK, received #{bytes} bytes"
             else
               send_action_not_taken
             end
@@ -125,7 +125,7 @@ module EM::FTPD
           tmpfile.flush
           @driver.put_file(target_path, tmpfile.path) do |bytes|
             if bytes
-              send_response "200 OK, received #{bytes} bytes"
+              send_response "226 OK, received #{bytes} bytes"
             else
               send_action_not_taken
             end


### PR DESCRIPTION
Hi, I'm working with a FTP client that's suffering with the response code of the STOR command. It expects the code to be 226 (closing data connection) and not 200 as it's [currently](https://github.com/yob/em-ftpd/blob/master/lib/em-ftpd/files.rb#L128) implemented in em-ftpd.

Based on a quick research in the RFC959 (page 50) the change seems legit. It's also pointed [here](http://cr.yp.to/ftp/stor.html).

200 is making the client keep the connection open and hold the transfer until it times out even though the data is correctly transfered.

WDYT?

Thanks a lot for the great library.
