### PR TITLE
gemspec: remove spec.has_rdoc

### DIFF
--- a/em-ftpd.gemspec
+++ b/em-ftpd.gemspec
@@ -5,7 +5,6 @@ Gem::Specification.new do |spec|
   spec.description = "Build a custom FTP daemon backed by a datastore of your choice"
   spec.files =  Dir.glob("{bin,examples,lib}/**/**/*") + ["Gemfile", "README.markdown","MIT-LICENSE"]
   spec.executables << "em-ftpd"
-  spec.has_rdoc = true
   spec.extra_rdoc_files = %w{README.markdown MIT-LICENSE }
   spec.rdoc_options << '--title' << 'EM::FTPd Documentation' <<
                        '--main'  << 'README.markdown' << '-q'


### PR DESCRIPTION
Based on this warning when I ran `bundle`:

	NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
	Gem::Specification#has_rdoc= called from ~/Workspace/em-ftpd/em-ftpd.gemspec:8.