### PR TITLE
remove support for user, group and daemonise in the configuration

### DIFF
--- a/em-ftpd.gemspec
+++ b/em-ftpd.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |spec|
   spec.name = "em-ftpd"
   spec.version = "0.0.1"
-  spec.summary = "An FTP daemon framework"
-  spec.description = "Build a custom FTP daemon backed by a datastore of your choice"
+  spec.summary = "An FTP server framework"
+  spec.description = "Build a custom FTP server backed by a datastore of your choice"
   spec.files =  Dir.glob("{bin,examples,lib}/**/**/*") + ["Gemfile", "README.markdown","MIT-LICENSE"]
   spec.executables << "em-ftpd"
   spec.has_rdoc = true

--- a/examples/fake.rb
+++ b/examples/fake.rb
@@ -83,8 +83,5 @@ end
 # configure the server
 driver     FakeFTPDriver
 #driver_args 1, 2, 3
-#user      "ftp"
-#group     "ftp"
-#daemonise false
 #name      "fakeftp"
 #pid_file  "/var/run/fakeftp.pid"

--- a/lib/em-ftpd/configurator.rb
+++ b/lib/em-ftpd/configurator.rb
@@ -5,49 +5,12 @@ module EM::FTPD
   class Configurator
 
     def initialize
-      @user      = nil
-      @group     = nil
-      @daemonise = false
       @name      = nil
       @pid_file  = nil
       @port      = 21
 
       @driver    = nil
       @driver_args = []
-    end
-
-    def user(val = nil)
-      get_or_set(:user, val, :to_s)
-    end
-
-    def uid
-      return nil if @user.nil?
-
-      begin
-        detail = Etc.getpwnam(@user)
-        return detail.uid
-      rescue
-        $stderr.puts "user must be nil or a real account" if detail.nil?
-      end
-    end
-
-    def group(val = nil)
-      get_or_set(:group, val, :to_s)
-    end
-
-    def gid
-      return nil if @group.nil?
-
-      begin
-        detail = Etc.getgrnam(@group)
-        return detail.gid
-      rescue
-        $stderr.puts "group must be nil or a real group" if detail.nil?
-      end
-    end
-
-    def daemonise(val = nil)
-      get_or_set(:daemonise, val)
     end
 
     def driver(klass = nil)

--- a/spec/em-ftpd/configurator_spec.rb
+++ b/spec/em-ftpd/configurator_spec.rb
@@ -3,21 +3,6 @@ require 'ostruct'
 
 describe EM::FTPD::Configurator do  
   describe "initialization" do    
-    describe '#user' do
-      subject { super().user }
-      it { is_expected.to be_nil }
-    end
-
-    describe '#group' do
-      subject { super().group }
-      it { is_expected.to be_nil }
-    end
-
-    describe '#daemonise' do
-      subject { super().daemonise }
-      it { is_expected.to be_falsey }
-    end
-
     describe '#name' do
       subject { super().name }
       it { is_expected.to be_nil }
@@ -42,77 +27,6 @@ describe EM::FTPD::Configurator do
       subject { super().driver_args }
       it { is_expected.to eq([ ]) }
     end
-  end
-  
-  describe "#user" do
-    it "should set the user to the specified value" do
-      subject.user 'bob'
-      expect(subject.user).to eq('bob')
-    end
-    
-    it "should set the value to a String if another input type is given" do
-      subject.user :bob
-      expect(subject.user).to eq('bob')
-    end
-  end
-
-  describe "#uid" do
-    it "should retrieve the user id based on the user name" do
-      subject.user 'justin'
-      expect(Etc).to receive(:getpwnam).with('justin').and_return(OpenStruct.new(:uid => 501))
-        
-      expect(subject.uid).to eq(501)
-    end
-    
-    it "should return nil when the user is not set" do
-      expect(subject.uid).to be_nil
-    end
-    
-    it "should print an error and capture an Exception if the user entry is not able to be determined with Etc.getpwnam" do
-      subject.user 'justin'
-      expect(Etc).to receive(:getpwnam).with('justin').and_return(nil)
-      expect($stderr).to receive(:puts).with('user must be nil or a real account')
-      expect { subject.uid }.to_not raise_error
-    end
-  end
-    
-
-  describe "#group" do
-    it "should set the group to the specified value" do
-      subject.group 'staff'
-      expect(subject.group).to eq('staff')
-    end
-    
-    it "should set the value to a String if another input type is given" do
-      subject.group :staff
-      expect(subject.group).to eq('staff')
-    end    
-  end
-
-  describe "#gid" do
-    it "should retrieve the group id based on the group name" do
-      subject.group 'testgroup'
-      expect(Etc).to receive(:getgrnam).with('testgroup').and_return(Struct::Group.new('staff', '*', 20, ['root']))
-      expect(subject.gid).to eq(20)
-    end
-    
-    it "should return nil when the group is not set" do
-      expect(subject.gid).to be_nil
-    end
-    
-    it "should print an error and capture an Exception  if the group entry is not able to be determined with Etc.getgrnam" do
-      subject.group 'testgroup'
-      expect(Etc).to receive(:getgrnam).with('testgroup').and_return(nil)
-      expect($stderr).to receive(:puts).with('group must be nil or a real group')
-      expect { subject.gid }.to_not raise_error
-    end
-  end
-
-  describe "#daemonise" do
-    it "should set the daemonise option to the specified value" do
-      subject.daemonise true
-      expect(subject.daemonise).to be_truthy
-    end    
   end
 
   describe "#driver" do


### PR DESCRIPTION
I posit that most users of a tool like this today will be deploying using tooling that takes care of concerns like the uid, gid and daemonisation - whether that be systemd, docker, kubernetes, or what-have-you. Even in the absence of those tools, my personal view is that those concerns are better handled by a simple wrapping shell script. This allows the configuration and testing surface area of a tool like this to be as small as possible.

This will be a _breaking change_ for current users of this gem, so perhaps it should be part of a v1.x (or v2.x?) release if that's a concern.

I also replaced the word "daemon" in the gemspec with "server" to reflect this attempt at modernisation.