### PR TITLE
Update development dependencies

### DIFF
--- a/em-ftpd.gemspec
+++ b/em-ftpd.gemspec
@@ -13,9 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage = "http://github.com/yob/em-ftpd"
   spec.required_ruby_version = ">=2.2"
 
-  spec.add_development_dependency("rake", "~> 10.0")
+  spec.add_development_dependency("rake", ">= 10")
   spec.add_development_dependency("rspec", "~>3.0")
-  spec.add_development_dependency("em-redis")
 
   spec.add_dependency('eventmachine')
 end


### PR DESCRIPTION
* allow any recent version of rake
* remove em-redis - there's no in-repo redis example any more